### PR TITLE
Reference TypeScript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,6 @@
     "gulp": "^3.8.8",
     "gulp-typescript": "^2.2.0",
     "gulp-rename": "^1.2.0"
-  }
+  },
+  "types": "./Scripts/typings/node/node.d.ts"
 }


### PR DESCRIPTION
There is no need referencing `LRUCache` with `/// <reference path="node_modules/lru-ts/index.d.ts" />`. You can add `types` to your `package.json` to help TypeScript finding your definitions. 😃 

Reference: http://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html
